### PR TITLE
Fix DataTransformer

### DIFF
--- a/src/DataTransformer/EmailToUserTransformer.php
+++ b/src/DataTransformer/EmailToUserTransformer.php
@@ -63,6 +63,10 @@ class EmailToUserTransformer implements DataTransformerInterface
      */
     public function reverseTransform($value)
     {
+        if (!$value) {
+            return;
+        }
+        
         $callBack = $this->finderCallback;
         $user = $callBack($this->userRepository, $value);
 


### PR DESCRIPTION
You have to return null when you dont have $value, so it doesn't throw and other constraints can be applied